### PR TITLE
vimode: % searches for first suitable character

### DIFF
--- a/vimode/src/cmds/motion.c
+++ b/vimode/src/cmds/motion.c
@@ -353,10 +353,12 @@ void cmd_goto_column(CmdContext *c, CmdParams *p)
 
 void cmd_goto_matching_brace(CmdContext *c, CmdParams *p)
 {
-	gint matching_pos;
 	gint pos = p->pos;
-	while (pos < p->line_end_pos) {
-		if ((matching_pos = SSM(p->sci, SCI_BRACEMATCH, pos, 0)) != -1) {
+	while (pos < p->line_end_pos)
+	{
+		gint matching_pos = SSM(p->sci, SCI_BRACEMATCH, pos, 0);
+		if (matching_pos != -1)
+		{
 			SET_POS(p->sci, matching_pos, TRUE);
 			return;
 		}

--- a/vimode/src/cmds/motion.c
+++ b/vimode/src/cmds/motion.c
@@ -353,9 +353,15 @@ void cmd_goto_column(CmdContext *c, CmdParams *p)
 
 void cmd_goto_matching_brace(CmdContext *c, CmdParams *p)
 {
-	gint pos = SSM(p->sci, SCI_BRACEMATCH, p->pos, 0);
-	if (pos != -1)
-		SET_POS(p->sci, pos, TRUE);
+	gint matching_pos;
+	gint pos = p->pos;
+	while (pos < p->line_end_pos) {
+		if ((matching_pos = SSM(p->sci, SCI_BRACEMATCH, pos, 0)) != -1) {
+			SET_POS(p->sci, matching_pos, TRUE);
+			return;
+		}
+		pos++;
+	}
 }
 
 


### PR DESCRIPTION
`:help %` specifies:
> Find the next item in this line after or under the cursor and jump to
> its match.